### PR TITLE
Resolve warning 'Invalid name: "Calculator App"' , README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Scan the QR code from the above link with your Expo App with Android/Iphone
 ### How to Load the App
 ```
 git clone https://github.com/oliver-gomes/react-native-calculator.git
+cd react-native-calculator
 npm install
 npm start
 ```

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "ios": "expo start --ios",
     "eject": "expo eject"
   },
-  "name": "Calculator App",
+  "name": "Calculator-App",
   "dependencies": {
     "eslint": "^5.13.0",
     "expo": "^32.0.0",


### PR DESCRIPTION
This pull request resolves warning

```
npm WARN Invalid name: "Calculator App"
```

and updates README so `cd` happens before `nom install`